### PR TITLE
Fix logical comparision

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector/Fixture/no_isset_on_expr.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector/Fixture/no_isset_on_expr.php.inc
@@ -20,7 +20,7 @@ final class NoIssetOnExpr
 {
     public function run($backedEnumClassName, $backedEnumValue)
     {
-        if ($backedEnumClassName::tryFrom($backedEnumValue) !== null) {
+        if ($backedEnumClassName::tryFrom($backedEnumValue) === null) {
             throw new \Symfony\Component\DependencyInjection\Exception\RuntimeException(sprintf('Enum value "%s" is not backed by "%s".', $backedEnumValue, $backedEnumClassName));
         }
         return $backedEnumClassName::tryFrom($backedEnumValue);

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\BinaryOp\Identical;
-use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\ConstFetch;

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\BinaryOp\Identical;
-use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\ConstFetch;
@@ -253,7 +253,7 @@ CODE_SAMPLE
         if ($conditionalExpr instanceof Variable || $conditionalExpr instanceof ArrayDimFetch || $conditionalExpr instanceof PropertyFetch) {
             $booleanNot = new BooleanNot(new Isset_([$conditionalExpr]));
         } else {
-            $booleanNot = new NotIdentical($conditionalExpr, new ConstFetch(new Name('null')));
+            $booleanNot = new Identical($conditionalExpr, new ConstFetch(new Name('null')));
         }
 
         return new If_($booleanNot, [


### PR DESCRIPTION
Hello

Here is the fix proposed in the [DowngradeThrowExprRector logical error](https://github.com/rectorphp/rector-downgrade-php/issues/264) issue. 

### Why

When downgrading a coalesce operator that uses throw, there is a logical error in how the condition is generated. In the current implementation, the exception is thrown when the left-hand side is not null, but it should be thrown when the left-hand side is null.

